### PR TITLE
New macros

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -68,6 +68,22 @@ pub unsafe fn ATTACK<A: ToF32, B: ToF32, C: ToF32>(fighter: &mut L2CAgentBase, i
 }
 
 #[inline]
+pub unsafe fn ATTACK_IGNORE_THROW<A: ToF32, B: ToF32, C: ToF32>(fighter: &mut L2CAgentBase, id: u64, part: u64, bone: Hash40, damage: f32, angle: u64, kbg: u64, fkb: u64, bkb: u64, size: C, x: f32, y: f32, z: f32,
+                    x2: Option<f32>, y2: Option<f32>, z2: Option<f32>, hitlag: f32, sdi: f32, clang: i32, facing: i32, set_weight: bool, shield_damage: A, trip: f32, rehit: B, reflectable: bool,
+                    absorbable: bool, flinchless: bool, disable_hitlag: bool, direct: bool, ground_air: i32, hitbits: i32, collision_part: i32, friendly_fire: bool, effect: Hash40, sfx_level: i32, collision_sound: i32, _type: i32) {
+    fighter.clear_lua_stack();
+    lua_args!(fighter, id, part, bone, damage, angle, kbg, fkb, bkb, size.to_f32(), x, y, z);
+    if let Some(x2) = x2 { lua_args!(fighter, x2); } else { fighter.push_lua_stack(&mut L2CValue::new()); }
+    if let Some(y2) = y2 { lua_args!(fighter, y2); } else { fighter.push_lua_stack(&mut L2CValue::new()); }
+    if let Some(z2) = z2 { lua_args!(fighter, z2); } else { fighter.push_lua_stack(&mut L2CValue::new()); }
+    lua_args!(fighter, hitlag, sdi, clang, facing, set_weight);
+    let dmg = shield_damage.to_f32();
+    if (dmg.is_nan()) { fighter.push_lua_stack(&mut Hash40::new("no").into()); } else { fighter.push_lua_stack(&mut dmg.into()); }
+    lua_args!(fighter, trip, rehit.to_f32(), reflectable, absorbable, flinchless, disable_hitlag, direct, ground_air, hitbits, collision_part, friendly_fire, effect, sfx_level, collision_sound, _type);
+    sv_animcmd::ATTACK_IGNORE_THROW(fighter.lua_state_agent);
+}
+
+#[inline]
 pub unsafe fn ATK_POWER<F: ToF32>(fighter: &mut L2CAgentBase, id: u64, power: F) {
     fighter.clear_lua_stack();
     lua_args!(fighter, id, power.to_f32());
@@ -118,6 +134,14 @@ pub unsafe fn FT_MOTION_RATE<F: ToF32>(fighter: &mut L2CAgentBase, rate: F) {
 }
 
 #[inline]
+pub unsafe fn FT_NEAR_LEAVE_OTTOTTO<A: ToF32, B: ToF32>(fighter: &mut L2CAgentBase, unk1: A, unk2: B) {
+    fighter.clear_lua_stack();
+    lua_args!(fighter, unk1.to_f32(), unk2.to_f32());
+    sv_animcmd::FT_NEAR_LEAVE_OTTOTTO(fighter.lua_state_agent);
+    fighter.clear_lua_stack();
+}
+
+#[inline]
 pub unsafe fn FT_START_ADJUST_MOTION_FRAME_arg1(fighter: &mut L2CAgentBase, arg: u64) {
     fighter.clear_lua_stack();
     lua_args!(fighter, arg);
@@ -162,6 +186,14 @@ pub unsafe fn ATK_SET_SHIELD_SETOFF_MUL_arg3(fighter: &mut L2CAgentBase, unk: u6
     fighter.clear_lua_stack();
     lua_args!(fighter, unk, unk2, unk3);
     sv_animcmd::ATK_SET_SHIELD_SETOFF_MUL_arg3(fighter.lua_state_agent);
+    fighter.clear_lua_stack();
+}
+
+#[inline]
+pub unsafe fn ATK_LERP_RATIO <A: ToF32> (fighter: &mut L2CAgentBase, ratio: A) {
+    fighter.clear_lua_stack();
+    lua_args!(fighter, ratio);
+    sv_animcmd::ATK_LERP_RATIO(fighter.lua_state_agent);
     fighter.clear_lua_stack();
 }
 
@@ -310,6 +342,29 @@ pub unsafe fn LANDING_EFFECT<
 }
 
 #[inline]
+pub unsafe fn LANDING_EFFECT_FLIP<
+    A: ToF32,
+    B: ToF32,
+    C: ToF32,
+    D: ToF32,
+    E: ToF32,
+    F: ToF32,
+    G: ToF32,
+    H: ToF32,
+    I: ToF32,
+    J: ToF32,
+    K: ToF32,
+    L: ToF32,
+    M: ToF32
+    >(fighter: &mut L2CAgentBase, left_effect: Hash40, right_effect: Hash40, bone: Hash40, unk1: A, unk2: B, unk3: C, unk4: D, unk5: E, unk6: F, unk7: G, unk8: H, unk9: I,
+    unk10: J, unk11: K, unk12: L, unk13: M, unk14: bool, axis: i32) {
+    fighter.clear_lua_stack();
+    lua_args!(fighter, left_effect, right_effect, bone, unk1.to_f32(), unk2.to_f32(), unk3.to_f32(), unk4.to_f32(), unk5.to_f32(), unk6.to_f32(), unk7.to_f32(), unk8.to_f32(), unk9.to_f32(), unk10.to_f32(), unk11.to_f32(), unk12.to_f32(), unk13.to_f32(), unk14, axis);
+    sv_animcmd::LANDING_EFFECT_FLIP(fighter.lua_state_agent);
+    fighter.clear_lua_stack();
+}
+
+#[inline]
 pub unsafe fn LAST_EFFECT_SET_ALPHA<F: ToF32>(fighter: &mut L2CAgentBase, alpha: F) {
     fighter.clear_lua_stack();
     lua_args!(fighter, alpha.to_f32());
@@ -388,6 +443,30 @@ pub unsafe fn EFFECT_ALPHA<
 }
 
 #[inline]
+pub unsafe fn EFFECT_FLIP_ALPHA<
+    A: ToF32,
+    B: ToF32,
+    C: ToF32,
+    D: ToF32,
+    E: ToF32,
+    F: ToF32,
+    G: ToF32,
+    H: ToF32,
+    I: ToF32,
+    J: ToF32,
+    K: ToF32,
+    L: ToF32,
+    M: ToF32,
+    N: ToF32
+    >(fighter: &mut L2CAgentBase, left_effect: Hash40, right_effect: Hash40, bone: Hash40, unk1: A, unk2: B, unk3: C, unk4: D, unk5: E, unk6: F, size: G, unk8: H, unk9: I,
+    unk10: J, unk11: K, unk12: L, unk13: M, unk14: bool, axis: i32, alpha: N) {
+    fighter.clear_lua_stack();
+    lua_args!(fighter, left_effect, right_effect, bone, unk1.to_f32(), unk2.to_f32(), unk3.to_f32(), unk4.to_f32(), unk5.to_f32(), unk6.to_f32(), size.to_f32(), unk8.to_f32(), unk9.to_f32(), unk10.to_f32(), unk11.to_f32(), unk12.to_f32(), unk13.to_f32(), unk14, axis, alpha.to_f32());
+    sv_animcmd::EFFECT_FLIP_ALPHA(fighter.lua_state_agent);
+    fighter.clear_lua_stack();
+}
+
+#[inline]
 pub unsafe fn EFFECT_FOLLOW_FLIP<
     A: ToF32,
     B: ToF32,
@@ -396,10 +475,29 @@ pub unsafe fn EFFECT_FOLLOW_FLIP<
     E: ToF32,
     F: ToF32,
     G: ToF32
-    >(fighter: &mut L2CAgentBase, unk: Hash40, unk2: Hash40, bone: Hash40, unk3: A, unk4: B, unk5: C, unk6: D, unk7: E, unk8: F, unk9: G, unk10: bool, axis: i32) {
+    >(fighter: &mut L2CAgentBase, unk1: Hash40, unk2: Hash40, bone: Hash40, unk3: A, unk4: B, unk5: C, unk6: D, unk7: E, unk8: F, unk9: G, unk10: bool, axis: i32) {
     fighter.clear_lua_stack();
-    lua_args!(fighter, unk, unk2, bone, unk3.to_f32(), unk4.to_f32(), unk5.to_f32(), unk6.to_f32(), unk7.to_f32(), unk8.to_f32(), unk9.to_f32(), unk10, axis);
+    lua_args!(fighter, unk1, unk2, bone, unk3.to_f32(), unk4.to_f32(), unk5.to_f32(), unk6.to_f32(), unk7.to_f32(), unk8.to_f32(), unk9.to_f32(), unk10, axis);
     sv_animcmd::EFFECT_FOLLOW_FLIP(fighter.lua_state_agent);
+    fighter.clear_lua_stack();
+}
+
+#[inline]
+pub unsafe fn EFFECT_FOLLOW_FLIP_ALPHA<
+    A: ToF32,
+    B: ToF32,
+    C: ToF32,
+    D: ToF32,
+    E: ToF32,
+    F: ToF32,
+    G: ToF32,
+    H: ToF32
+    >(fighter: &mut L2CAgentBase, left_effect: Hash40, right_effect: Hash40, bone: Hash40, unk3: A, unk4: B, unk5: C, unk6: D, unk7: E, unk8: F, size: G, unk10: bool, 
+    axis: i32, alpha: H) {
+    fighter.clear_lua_stack();
+    lua_args!(fighter, left_effect, right_effect, bone, unk3.to_f32(), unk4.to_f32(), unk5.to_f32(), unk6.to_f32(), unk7.to_f32(), unk8.to_f32(), size.to_f32(),
+    unk10, axis, alpha.to_f32());
+    sv_animcmd::EFFECT_FOLLOW_FLIP_ALPHA(fighter.lua_state_agent);
     fighter.clear_lua_stack();
 }
 
@@ -549,6 +647,29 @@ pub unsafe fn PLAY_SE(fighter: &mut L2CAgentBase, se: Hash40) {
     fighter.clear_lua_stack();
 }
 
+#[inline]
+pub unsafe fn PLAY_STATUS(fighter: &mut L2CAgentBase, se: Hash40) {
+    fighter.clear_lua_stack();
+    lua_args!(fighter, se);
+    sv_animcmd::PLAY_STATUS(fighter.lua_state_agent);
+    fighter.clear_lua_stack();
+}
+
+#[inline]
+pub unsafe fn PLAY_LANDING_SE(fighter: &mut L2CAgentBase, se: Hash40) {
+    fighter.clear_lua_stack();
+    lua_args!(fighter, se);
+    sv_animcmd::PLAY_LANDING_SE(fighter.lua_state_agent);
+    fighter.clear_lua_stack();
+}
+
+#[inline]
+pub unsafe fn PLAY_SE_NO_3D(fighter: &mut L2CAgentBase, se: Hash40) {
+    fighter.clear_lua_stack();
+    lua_args!(fighter, se);
+    sv_animcmd::PLAY_SE_NO_3D(fighter.lua_state_agent);
+    fighter.clear_lua_stack();
+}
 
 #[inline]
 pub unsafe fn PLAY_SE_REMAIN(fighter: &mut L2CAgentBase, se: Hash40) {
@@ -579,6 +700,14 @@ pub unsafe fn PLAY_SEQUENCE(fighter: &mut L2CAgentBase, sequence: Hash40) {
     fighter.clear_lua_stack();
     lua_args!(fighter, sequence);
     sv_animcmd::PLAY_SEQUENCE(fighter.lua_state_agent);
+    fighter.clear_lua_stack();
+}
+
+#[inline]
+pub unsafe fn SET_PLAY_INHIVIT<A: ToF32>(fighter: &mut L2CAgentBase, se: Hash40, unk: A) {
+    fighter.clear_lua_stack();
+    lua_args!(fighter, se, unk);
+    sv_animcmd::SET_PLAY_INHIVIT(fighter.lua_state_agent);
     fighter.clear_lua_stack();
 }
 
@@ -635,6 +764,26 @@ pub unsafe fn COL_PRI(fighter: &mut L2CAgentBase, pri: u64) {
     fighter.clear_lua_stack();
     lua_args!(fighter, pri);
     sv_animcmd::COL_PRI(fighter.lua_state_agent);
+    fighter.clear_lua_stack();
+}
+
+#[inline]
+pub unsafe fn AREA_WIND_2ND_RAD<
+    A: ToF32, B: ToF32, C: ToF32, D: ToF32, E: ToF32, F: ToF32, G: ToF32, H: ToF32
+    >(fighter: &mut L2CAgentBase, unk1: A unk2: B, unk3: C, unk4: D, unk5: E, unk6: F, unk7: G, unk8: H) {
+    fighter.clear_lua_stack();
+    lua_args!(fighter, unk1.to_f32(), unk2.to_f32(), unk3.to_f32(), unk4.to_f32(), unk5.to_f32(), unk6.to_f32(), unk7.to_f32(), unk8.to_f32());
+    sv_animcmd::AREA_WIND_2ND_RAD(fighter.lua_state_agent);
+    fighter.clear_lua_stack();
+}
+
+#[inline]
+pub unsafe fn AREA_WIND_2ND_RAD_arg9<
+    A: ToF32, B: ToF32, C: ToF32, D: ToF32, E: ToF32, F: ToF32, G: ToF32, H: ToF32, I: ToF32
+    >(fighter: &mut L2CAgentBase, unk1: A unk2: B, unk3: C, unk4: D, unk5: E, unk6: F, unk7: G, unk8: H, unk9: I) {
+    fighter.clear_lua_stack();
+    lua_args!(fighter, unk1.to_f32(), unk2.to_f32(), unk3.to_f32(), unk4.to_f32(), unk5.to_f32(), unk6.to_f32(), unk7.to_f32(), unk8.to_f32(), unk9.to_f32());
+    sv_animcmd::AREA_WIND_2ND_RAD_arg9(fighter.lua_state_agent);
     fighter.clear_lua_stack();
 }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -52,7 +52,7 @@ macro_rules! lua_args {
 }
 
 #[inline]
-pub unsafe fn ATTACK<A: ToF32, B: ToF32, C: ToF32>(fighter: &mut L2CAgentBase, id: u64, part: u64, bone: Hash40, damage: f32, angle: u64, kbg: u64, fkb: u64, bkb: u64, size: C, x: f32, y: f32, z: f32,
+pub unsafe fn ATTACK<A: ToF32, B: ToF32, C: ToF32>(fighter: &mut L2CAgentBase, id: u64, part: u64, bone: Hash40, damage: f32, angle: u64, kbg: i32, fkb: i32, bkb: i32, size: C, x: f32, y: f32, z: f32,
                     x2: Option<f32>, y2: Option<f32>, z2: Option<f32>, hitlag: f32, sdi: f32, clang: i32, facing: i32, set_weight: bool, shield_damage: A, trip: f32, rehit: B, reflectable: bool,
                     absorbable: bool, flinchless: bool, disable_hitlag: bool, direct: bool, ground_air: i32, hitbits: i32, collision_part: i32, friendly_fire: bool, effect: Hash40, sfx_level: i32, collision_sound: i32, _type: i32) {
     fighter.clear_lua_stack();
@@ -68,7 +68,7 @@ pub unsafe fn ATTACK<A: ToF32, B: ToF32, C: ToF32>(fighter: &mut L2CAgentBase, i
 }
 
 #[inline]
-pub unsafe fn ATTACK_IGNORE_THROW<A: ToF32, B: ToF32, C: ToF32>(fighter: &mut L2CAgentBase, id: u64, part: u64, bone: Hash40, damage: f32, angle: u64, kbg: u64, fkb: u64, bkb: u64, size: C, x: f32, y: f32, z: f32,
+pub unsafe fn ATTACK_IGNORE_THROW<A: ToF32, B: ToF32, C: ToF32>(fighter: &mut L2CAgentBase, id: u64, part: u64, bone: Hash40, damage: f32, angle: u64, kbg: i32, fkb: i32, bkb: i32, size: C, x: f32, y: f32, z: f32,
                     x2: Option<f32>, y2: Option<f32>, z2: Option<f32>, hitlag: f32, sdi: f32, clang: i32, facing: i32, set_weight: bool, shield_damage: A, trip: f32, rehit: B, reflectable: bool,
                     absorbable: bool, flinchless: bool, disable_hitlag: bool, direct: bool, ground_air: i32, hitbits: i32, collision_part: i32, friendly_fire: bool, effect: Hash40, sfx_level: i32, collision_sound: i32, _type: i32) {
     fighter.clear_lua_stack();
@@ -92,7 +92,7 @@ pub unsafe fn ATK_POWER<F: ToF32>(fighter: &mut L2CAgentBase, id: u64, power: F)
 }
 
 #[inline]
-pub unsafe fn ATTACK_ABS(fighter: &mut L2CAgentBase, kind: i32, id: u64, damage: f32, angle: u64, kbg: u64, fkb: u64, bkb: u64, hitlag: f32,
+pub unsafe fn ATTACK_ABS(fighter: &mut L2CAgentBase, kind: i32, id: u64, damage: f32, angle: u64, kbg: i32, fkb: i32, bkb: i32, hitlag: f32,
                         unk: f32, facing: i32, unk2: f32, unk3: bool, effect: Hash40, sfx_level: i32, sfx_type: i32, _type: i32) {
     fighter.clear_lua_stack();
     lua_args!(fighter, kind, id, damage, angle, kbg, fkb, bkb, hitlag, unk, facing, unk2, unk3, effect, sfx_level, sfx_type, _type);

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -134,10 +134,10 @@ pub unsafe fn FT_MOTION_RATE<F: ToF32>(fighter: &mut L2CAgentBase, rate: F) {
 }
 
 #[inline]
-pub unsafe fn FT_NEAR_LEAVE_OTTOTTO<A: ToF32, B: ToF32>(fighter: &mut L2CAgentBase, unk1: A, unk2: B) {
+pub unsafe fn FT_LEAVE_NEAR_OTTOTTO<A: ToF32, B: ToF32>(fighter: &mut L2CAgentBase, unk1: A, unk2: B) {
     fighter.clear_lua_stack();
     lua_args!(fighter, unk1.to_f32(), unk2.to_f32());
-    sv_animcmd::FT_NEAR_LEAVE_OTTOTTO(fighter.lua_state_agent);
+    sv_animcmd::FT_LEAVE_NEAR_OTTOTTO(fighter.lua_state_agent);
     fighter.clear_lua_stack();
 }
 


### PR DESCRIPTION
- FT_NEAR_LEAVE_OTTOTTO
- ATTACK_IGNORE_THROW
- PLAY_STATUS, PLAY_LANDING_SE, PLAY_SE_NO_3D
- AREA_WIND_2ND_RAD, AREA_WIND_2ND_RAD_arg9
- EFFECT_FOLLOW_FLIP_ALPHA, EFFECT_FLIP_ALPHA, LANDING_EFFECT_FLIP (btw the two hash40 args in all the flip functions are for different effects, the function technically spawns a different effect based on the direction you're facing)
- ATK_LERP_RATIO
- SET_PLAY_INHIVIT